### PR TITLE
Allow  route exception definition with expressions

### DIFF
--- a/src/CSRF.php
+++ b/src/CSRF.php
@@ -66,7 +66,7 @@ class CSRF extends Anchor
         }
 
         $pattern = static::getPathExpression(Request::getPathInfo());
-        if (!is_null($pattern) and in_array($pattern, static::$config['EXCEPT'])) {
+        if (!is_null($pattern) && in_array($pattern, static::$config['EXCEPT'])) {
             return true;
         }
 

--- a/src/CSRF.php
+++ b/src/CSRF.php
@@ -41,9 +41,32 @@ class CSRF extends Anchor
         }
     }
 
+    public static function getPathExpression($url): mixed
+    {
+        foreach (static::$config['EXCEPT'] as $pattern) {
+            $regex = '#^' . strtr(preg_quote($pattern, '#'), [
+                '\{int\}' => '(\d+)',           # number based values
+                '\{slug\}' => '([a-z0-9-]+)',   # alpha numerical values
+                '\{any\}' => '([^/]+?)',        # anything except slashes
+                '\{wild\}' => '(.*)'            # wild card
+            ]) . '$#i';
+
+            if (preg_match($regex, $url, $matches)) {
+                return $pattern;
+            }
+        }
+
+        return null;
+    }
+
     public static function verify(): bool
     {
         if (in_array(Request::getPathInfo(), static::$config['EXCEPT'])) {
+            return true;
+        }
+
+        $pattern = static::getPathExpression(Request::getPathInfo());
+        if (!is_null($pattern) and in_array($pattern, static::$config['EXCEPT'])) {
             return true;
         }
 


### PR DESCRIPTION
## Description

This update enhances the CSRF package by introducing a new method, `getPathExpression`, which significantly allows the routes to be whitelisted in batches using a single expression.

Previously, each routes had to be specified manually  in the EXCEPT array, making the process cumbersome, especially for applications with numerous, dynamic, or migrating routes. The new method allows developers to define route patterns using placeholders such as {int}, {slug}, {any}, and {wild}, making it easier to whitelist multiple routes with similar structures

### Before

```php
Leaf\Anchor\CSRFF::config([
  "METHODS" => [...METHODS],
  "EXCEPT" => [
      "app/flash/1",
      "app/flash/2",
      "api/v1/user",
      "api/v1/product",
      "hook/abc",
      "hook/xyz",
      // more routes...
  ],
]);
```
### After

```php
Leaf\Anchor\CSRFF::config([
  "METHODS" => [...METHODS],
  "EXCEPT" => [
      "simple/route",
      "app/flash/{int}",
      "api/{any}",
      "hook/{wild}",
  ],
]);
```

This change does not break any existing features, as it extends the current functionality in a backward-compatible way. It simplifies the process of configuring CSRF exceptions.

## Related Issue

#5 