### PR TITLE
Fix: CSRF Package Initialization and Configuration Handling

### DIFF
--- a/src/CSRF.php
+++ b/src/CSRF.php
@@ -23,6 +23,10 @@ class CSRF extends Anchor
      */
     public static function config($config = null)
     {
+        if (file_exists('config/csrf.php')) {
+            static::$config = require 'config/csrf.php';
+        }
+        
         if ($config === null) {
             return static::$config;
         }

--- a/src/scripts.php
+++ b/src/scripts.php
@@ -4,6 +4,7 @@ if (class_exists('\Leaf\Config')) {
     \Leaf\Config::addScript(function () {
         if (!\Leaf\Anchor\CSRF::token()) {
             \Leaf\Anchor\CSRF::init();
+            \Leaf\Anchor\CSRF::config();
         }
 
         if (!\Leaf\Anchor\CSRF::verify()) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

This pull request addresses the following issues with the CSRF package:

- Initialization Order: The `\Leaf\Anchor\CSRF::config()` method is now called before request verification begins, ensuring that any custom configurations are properly applied before verification occurs.
- Custom Configuration Support: The code now checks if a `csrf.php` configuration file exists. If it does, the settings from this file will replace the default configurations in `Leaf\Anchor::$config`. This allows users to define custom CSRF rules more effectively.

These changes will help prevent unexpected invalidation of requests and ensure that user-defined configurations are respected.

## Does this PR introduce a breaking change? 

The changes are backward-compatible and should not introduce any breaking changes.

- [x] Has an Issue
- [ ] Breaking changes

## Related Issue

#7 